### PR TITLE
Fix double forward slash on SSL dir paths

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@ class pe_failover::params {
   $rsync_user                    = 'pe-transfer'
   $rsync_user_home               = "/home/${rsync_user}"
   $rsync_user_ssh_id             = "${rsync_user_home}/.ssh/pe_failover_id_rsa"
-  $rsync_ssl_dir                 = '/etc/puppetlabs/puppet/ssl/'
+  $rsync_ssl_dir                 = '/etc/puppetlabs/puppet/ssl'
   $rsync_command                 = 'rsync -au --delete'
   $pe_failover_directory         = '/opt/pe_failover'
   $script_directory              = "${pe_failover_directory}/scripts"

--- a/templates/sync_certs.sh.erb
+++ b/templates/sync_certs.sh.erb
@@ -7,7 +7,7 @@ logger "PE_FAILOVER: ${SCRIPTNAME} ---> [SUCCESS] Starting sync of Puppet CA dir
 <%= @rsync_command %> \
   -e '/usr/bin/ssh -i <%= @rsync_user_ssh_id %>' \
   --exclude-from='<%= @rsync_ssl_dir %>/rsync_exclude' \
-  <%= @rsync_ssl_dir %> <%= @rsync_user %>@<%= @passive_master %>:<%= @cert_dump_path %>/latest/
+  <%= @rsync_ssl_dir %>/ <%= @rsync_user %>@<%= @passive_master %>:<%= @cert_dump_path %>/latest/
 
 result="$?"
 if [[ $result -eq 0 ]]; then


### PR DESCRIPTION
Prior to this, some of the scripts that were being made had double forward slashes in them. Likely not breaking anything, but still something that could be cleaned up.
